### PR TITLE
Updated Speedtest Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   speedtest:
     restart: always
-    image: frdmn/speedtest-grafana:latest
+    image: iamk3/docker-speedtest-grafana:latest
     container_name: speedtest
     environment:
       - "SPEEDTEST_INTERVAL=${SPEEDTEST_SPEEDTEST_INTERVAL}"

--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:10-slim AS get-speedtest
-
-RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-release -y
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-RUN echo "deb https://ookla.bintray.com/debian $(lsb_release -sc) main" | tee  /etc/apt/sources.list.d/speedtest.list
+FROM debian:11-slim AS get-speedtest
+RUN apt-get update && apt-get install -y curl gnupg apt-transport-https dirmngr lsb-release 
+RUN apt-get install -y debian-archive-keyring &> /dev/null
+RUN curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash
 RUN apt-get update
 RUN apt-get install speedtest
 


### PR DESCRIPTION
Bintray has been sunset by JFrog. Ookla has updated speedtest instructions. I have updated the speedtest container based on those instructions. The container is once again buildable from source.

Updated the docker-compose.yml to utilize the newest version of Grafana to mitigate any security issues seen in previous versions.

Updated the docker-compose.yml to utilize the newer build of the speedtest app currently hosted on my docker hub at https://hub.docker.com/r/iamk3/docker-speedtest-grafana